### PR TITLE
"HostnameChecker" and "ValidatorException" not available in Java9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.adito</groupId>
     <artifactId>trustmanager</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-java9</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>An implementation to check certificateException and let the user decide how to handle them</description>
@@ -61,7 +61,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -70,9 +70,8 @@
 
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.1</version>
                 <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
                     <archive>
                         <manifest>
                             <useUniqueVersions>true</useUniqueVersions>
@@ -86,14 +85,9 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>4.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -120,7 +114,7 @@
 
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.1</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/de/adito/trustmanager/confirmingui/CertificateExceptionDetail.java
+++ b/src/main/java/de/adito/trustmanager/confirmingui/CertificateExceptionDetail.java
@@ -2,8 +2,8 @@ package de.adito.trustmanager.confirmingui;
 
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.Oid;
-import sun.security.util.HostnameChecker;
 
+import java.lang.reflect.Method;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -144,11 +144,17 @@ public class CertificateExceptionDetail
     
     private static boolean _checkHostname(String pHostname, X509Certificate[] pChain)
     {
-        try
-        {
-            HostnameChecker.getInstance(HostnameChecker.TYPE_TLS).match(pHostname, pChain[0]);
+        try {
+            Class<?> checker = Class.forName("sun.security.util.HostnameChecker");
+            Method getInstance = checker.getMethod("getInstance", byte.class);
+            Object instance = getInstance.invoke(null, (byte) 1);
+            Method match = checker.getMethod("match", String.class, X509Certificate.class);
+            match.invoke(instance, pHostname, pChain[0]);
             return true;
-        } catch (CertificateException exc)
+        } catch ( ClassNotFoundException cnfe )
+        {
+            return true;
+        } catch (Exception exc)
         {
             return false;
         }

--- a/src/test/java/de/adito/trustmanager/Test_CertificateValidation.java
+++ b/src/test/java/de/adito/trustmanager/Test_CertificateValidation.java
@@ -4,7 +4,6 @@ import de.adito.trustmanager.confirmingui.CertificateExceptionDetail;
 import de.adito.trustmanager.store.ICustomTrustStore;
 import de.adito.trustmanager.store.JKSCustomTrustStore;
 import org.junit.*;
-import sun.security.validator.ValidatorException;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -131,7 +130,7 @@ public class Test_CertificateValidation
         } catch (Exception exc)
         {
             Throwable cause = exc.getCause();
-            if (cause instanceof ValidatorException)
+            if (cause.getClass().getSimpleName().equals("ValidatorException"))
             {
                 Throwable secondCause = cause.getCause();
                 if (secondCause instanceof CertPathValidatorException)


### PR DESCRIPTION
I did a small research, why our trustManager does not compile with Java9.
It's because the "HostnameChecker" and the "ValidatorException" is not publicly available anymore in JDK9+.
Is there a better solution, instead of Reflection? Maybe BouncyCastle provides a better one? I'm not very familiar with this topic...
My changes seem to work under Oracle JDK10, even all of your unit tests.

-> I deployed this artifact temporarily to our local nexus
