### PR TITLE
Fixed linux crash that was caused by a too big window

### DIFF
--- a/src/main/java/de/adito/trustmanager/confirmingui/CertificateExceptionDialog.java
+++ b/src/main/java/de/adito/trustmanager/confirmingui/CertificateExceptionDialog.java
@@ -18,7 +18,7 @@ class CertificateExceptionDialog extends JDialog
 {
     
     private JPanel extButtonPanel;
-    private JTextArea extendedDialog;
+    private JComponent extendedDialog;
     
     private ResourceBundle bundle;
     private boolean isExtended;
@@ -100,10 +100,15 @@ class CertificateExceptionDialog extends JDialog
     private void _createExtendedDialog()
     {
         //Text Handling
-        extendedDialog = new JTextArea(detailMsg);
+        JTextArea extendedDialogArea = new JTextArea(detailMsg);
+        extendedDialogArea.setEditable(false);
+        extendedDialogArea.setOpaque(false);
+        JScrollPane scrollPane = new JScrollPane(extendedDialogArea);
+        scrollPane.setBorder(null);
+        extendedDialog = new JPanel(new BorderLayout());
+        extendedDialog.setPreferredSize(new Dimension(getPreferredSize().width - 20, 200));
+        extendedDialog.add(scrollPane, BorderLayout.CENTER);
         extendedDialog.setBorder(BorderFactory.createEtchedBorder());
-        extendedDialog.setEditable(false);
-        extendedDialog.setOpaque(false);
 
         GridBagConstraints textConstraints = new GridBagConstraints();
         textConstraints.gridx = 0;


### PR DESCRIPTION
The exception dialog caused a gnome crash (Ubuntu 19.04), if the window / error message was too big. So I added a scrollpane to the dialog, so that the dialog only gets a specific amount of px in width.